### PR TITLE
Switch container registry to ghcr.io

### DIFF
--- a/.github/workflows/push-nonroot.yml
+++ b/.github/workflows/push-nonroot.yml
@@ -21,19 +21,11 @@ jobs:
     - name: Set version from tag
       if: startsWith(github.ref, 'refs/tags/v')
       run: echo VERSION="$(echo ${GITHUB_REF#refs/tags/})-nonroot" >> $GITHUB_ENV
-    - name: Push Image to docker.io
+    - name: Push Image to ghcr.io
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        registry: docker.io
+        registry: ghcr.io
         name: "${{ github.repository }}:${{ env.VERSION }}"
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        buildoptions: --target nonroot
-    - name: Push Image to quay.io
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        registry: quay.io
-        name: "${{ github.repository }}:${{ env.VERSION }}"
-        username: ${{ secrets.QUAY_IO_USERNAME }}
-        password: ${{ secrets.QUAY_IO_PASSWORD }}
+        username: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         buildoptions: --target nonroot

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,17 +21,10 @@ jobs:
     - name: Set version from tag
       if: startsWith(github.ref, 'refs/tags/v')
       run: echo VERSION=$(echo ${GITHUB_REF#refs/tags/}) >> $GITHUB_ENV
-    - name: Push Image to docker.io
+    - name: Push Image to ghcr.io
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        registry: docker.io
+        registry: ghcr.io
         name: "${{ github.repository }}:${{ env.VERSION }}"
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Push Image to quay.io
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        registry: quay.io
-        name: "${{ github.repository }}:${{ env.VERSION }}"
-        username: ${{ secrets.QUAY_IO_USERNAME }}
-        password: ${{ secrets.QUAY_IO_PASSWORD }}
+        username: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After the move to k8up-io organization, wrestic backports will no longer be pushed to docker.io and quay.io.
All legacy images are moved to ghrc.io/k8up-io/wrestic